### PR TITLE
Vrouter deployment

### DIFF
--- a/build_scripts/make_userdata_vrouter.sh
+++ b/build_scripts/make_userdata_vrouter.sh
@@ -4,65 +4,14 @@ cat <<EOF >userdata_vrouter.txt
 #!/bin/bash
 date
 set -x
-export LC_ALL=en_US.UTF-8
-export LANG=en_US.UTF-8
-export LANGUAGE=en_US.UTF-8
-export layout="${layout}"
-release="\$(lsb_release -cs)"
-sudo mkdir -p /etc/facter/facts.d
-if [ -n "${git_protocol}" ]; then
-  export git_protocol="${git_protocol}"
-fi
-export no_proxy="127.0.0.1,169.254.169.254,localhost,consul,jiocloudservices.com"
-internal_subnet_exclusion=",${env_subnet}"
-echo no_proxy="'127.0.0.1,169.254.169.254,localhost,consul,jiocloudservices.com\${internal_subnet_exclusion}'" >> /etc/environment
-if [ -n "${env_http_proxy}" ]
-then
-  export http_proxy=${env_http_proxy}
-  echo http_proxy="'${env_http_proxy}'" >> /etc/environment
-  echo "Acquire::http::Proxy \"${env_http_proxy}\";" > /etc/apt/apt.conf.d/03proxy
-fi
-if [ -n "${env_https_proxy}" ]
-then
-  export https_proxy=${env_https_proxy}
-  echo https_proxy="'${env_https_proxy}'" >> /etc/environment
-fi
-if [ -n "${dns_override}" ]; then
-  echo 'nameserver ${dns_override}' > /etc/resolv.conf
-fi
-wget -O puppet.deb -t 5 -T 30 http://apt.puppetlabs.com/puppetlabs-release-\${release}.deb
-if [ "${env}" == "at" ]
-then
-  jiocloud_repo_deb_url=http://jiocloud.rustedhalo.com/ubuntu/jiocloud-apt-\${release}-testing.deb
-else
-  jiocloud_repo_deb_url=http://jiocloud.rustedhalo.com/ubuntu/jiocloud-apt-\${release}.deb
-fi
-wget -O jiocloud.deb -t 5 -T 30 \${jiocloud_repo_deb_url}
-dpkg -i puppet.deb jiocloud.deb
 if [ -n "${puppet_vpc_repo_url}"];then
-  echo "deb [arch=amd64] ${puppet_vpc_repo_url} jiocloud main" | tee -a /etc/apt/sources.list
-  wget -qO - ${puppet_vpc_repo_url}/repo.key | apt-key add -
+  if [ -z "grep '${puppet_vpc_repo_url}' /etc/apt/sources.list" ];then
+    echo "deb [arch=amd64] ${puppet_vpc_repo_url} jiocloud main" | tee -a /etc/apt/sources.list
+    wget -qO - ${puppet_vpc_repo_url}/repo.key | apt-key add -
+  fi
 fi
-if no_proxy= wget -t 2 -T 30 -O internal.deb http://apt.internal.jiocloud.com/internal.deb
-then
-  dpkg -i internal.deb
-fi
-n=0
-#while [ \$n -le 5 ]
-#do
 apt-get update 
-apt-get install -y puppet software-properties-common puppet-vpc jiocloud-ssl-certificate
-  #n=\$((\$n+1))
-  #sleep 5
-#done
-if [ -n "${override_repo}" ]; then
-  echo "override_repo=${override_repo}" > /etc/facter/facts.d/override_repo.txt
-  time gem install faraday faraday_middleware --no-ri --no-rdoc;
-fi
-if [ -n "${python_jiocloud_source_repo}" ]; then
-  apt-get install -y python-pip python-jiocloud python-dev libffi-dev libssl-dev git
-  pip install -e "${python_jiocloud_source_repo}@${python_jiocloud_source_branch}#egg=jiocloud"
-fi
+apt-get install -y puppet software-properties-common puppet-vpc
 if [ -n "${puppet_modules_source_repo}" ]; then
   apt-get install -y git
   git clone ${puppet_modules_source_repo} /tmp/rjil
@@ -105,51 +54,8 @@ INISETTING
 else
   puppet apply --config_version='echo settings' -e "ini_setting { default_manifest: path => \"/etc/puppet/puppet.conf\", section => main, setting => default_manifest, value => \"/etc/puppet/manifests/site.pp\" }"
 fi
-echo 'consul_discovery_token='${consul_discovery_token} > /etc/facter/facts.d/consul.txt
-# default to first 16 bytes of discovery token
-echo 'consul_gossip_encrypt'=`echo ${consul_discovery_token} | cut -b 1-15 | base64` >> /etc/facter/facts.d/consul.txt
-echo 'current_version='${BUILD_NUMBER} > /etc/facter/facts.d/current_version.txt
 echo 'env='${env} > /etc/facter/facts.d/env.txt
 echo 'cloud_provider='${cloud_provider} > /etc/facter/facts.d/cloud_provider.txt
-if [ -n "${slack_url}" ]; then
-  echo 'slack_url=${slack_url}' > /etc/facter/facts.d/slack_url.txt
-fi
-
-##
-# Disable TCP Offloading in builds on Interfaces
-# Add network config for all available interfaces, this would be usable for
-# undercloud as it will have multiple interfaces. cloudinit will only handle
-# first interface
-#
-
-if [[ \$(facter is_virtual) == true ]];
-then
-  for nic in \$(ifconfig -a | awk '/eth[0-9]+/ {print \$1}'); do
-    netconfig_content="\$netconfig_content
-file { '/etc/network/interfaces.d/\${nic}':
-  ensure  => file,
-  content => 'auto \$nic
-iface \$nic inet dhcp
-',
-}"
-    ethtool -K \${nic} tx off
-    sed -i -e "/^exit 0$/i\ethtool -K \${nic} tx off" /etc/rc.local
-  done
-
-  puppet apply --config_version='echo settings' -e "\$netconfig_content"
-fi
-
-
-##
-# Workaround to add the swap partition for baremetal systems, as even though
-# cloudinit is creating the swap partition, its not added to the fstab and not
-# enabled.
-##
-if [ -e /dev/disk/by-label/swap1 ] && [ `grep -cP '^LABEL=swap1[\s\t]+' /etc/fstab` -eq 0 ]; then
-  echo 'LABEL=swap1 none swap sw 0 1' >> /etc/fstab
-  swapon -a
-fi
-
 while true
 do
   # first install all packages to make the build as fast as possible

--- a/build_scripts/make_userdata_vrouter.sh
+++ b/build_scripts/make_userdata_vrouter.sh
@@ -1,0 +1,171 @@
+#!/bin/bash -xe
+
+cat <<EOF >userdata_vrouter.txt
+#!/bin/bash
+date
+set -x
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8
+export LANGUAGE=en_US.UTF-8
+export layout="${layout}"
+release="\$(lsb_release -cs)"
+sudo mkdir -p /etc/facter/facts.d
+if [ -n "${git_protocol}" ]; then
+  export git_protocol="${git_protocol}"
+fi
+export no_proxy="127.0.0.1,169.254.169.254,localhost,consul,jiocloudservices.com"
+internal_subnet_exclusion=",${env_subnet}"
+echo no_proxy="'127.0.0.1,169.254.169.254,localhost,consul,jiocloudservices.com\${internal_subnet_exclusion}'" >> /etc/environment
+if [ -n "${env_http_proxy}" ]
+then
+  export http_proxy=${env_http_proxy}
+  echo http_proxy="'${env_http_proxy}'" >> /etc/environment
+fi
+if [ -n "${env_https_proxy}" ]
+then
+  export https_proxy=${env_https_proxy}
+  echo https_proxy="'${env_https_proxy}'" >> /etc/environment
+fi
+if [ -n "${dns_override}" ]; then
+  echo 'nameserver ${dns_override}' > /etc/resolv.conf
+fi
+wget -O puppet.deb -t 5 -T 30 http://apt.puppetlabs.com/puppetlabs-release-\${release}.deb
+if [ "${env}" == "at" ]
+then
+  jiocloud_repo_deb_url=http://jiocloud.rustedhalo.com/ubuntu/jiocloud-apt-\${release}-testing.deb
+else
+  jiocloud_repo_deb_url=http://jiocloud.rustedhalo.com/ubuntu/jiocloud-apt-\${release}.deb
+fi
+wget -O jiocloud.deb -t 5 -T 30 \${jiocloud_repo_deb_url}
+dpkg -i puppet.deb jiocloud.deb
+if [ -n "${puppet_vpc_repo_url}"]
+then
+  echo "deb [arch=amd64] ${puppet_vpc_repo_url} jiocloud main" | tee -a /etc/apt/sources.list
+  wget -qO - ${puppet_vpc_repo_url}/repo.key | apt-key add -
+fi
+if no_proxy= wget -t 2 -T 30 -O internal.deb http://apt.internal.jiocloud.com/internal.deb
+then
+  dpkg -i internal.deb
+fi
+n=0
+#while [ \$n -le 5 ]
+#do
+apt-get update 
+apt-get install -y puppet software-properties-common puppet-vpc jiocloud-ssl-certificate
+  #n=\$((\$n+1))
+  #sleep 5
+#done
+if [ -n "${override_repo}" ]; then
+  echo "override_repo=${override_repo}" > /etc/facter/facts.d/override_repo.txt
+  time gem install faraday faraday_middleware --no-ri --no-rdoc;
+fi
+if [ -n "${python_jiocloud_source_repo}" ]; then
+  apt-get install -y python-pip python-jiocloud python-dev libffi-dev libssl-dev git
+  pip install -e "${python_jiocloud_source_repo}@${python_jiocloud_source_branch}#egg=jiocloud"
+fi
+if [ -n "${puppet_modules_source_repo}" ]; then
+  apt-get install -y git
+  git clone ${puppet_modules_source_repo} /tmp/rjil
+  if [ -n "${puppet_modules_source_branch}" ]; then
+    pushd /tmp/rjil
+    git checkout ${puppet_modules_source_branch}
+    popd
+  fi
+  if [ -n "${pull_request_id}" ]; then
+    pushd /tmp/rjil
+    git fetch origin pull/${pull_request_id}/head:test_${pull_request_id}
+    git config user.email "testuser@localhost.com"
+    git config user.name "Test User"
+    git merge -m 'Merging Pull Request' test_${pull_request_id}
+    popd
+  fi
+  time gem install librarian-puppet-simple --no-ri --no-rdoc;
+  mkdir -p /etc/puppet/manifests.overrides
+  cp /tmp/rjil/site.pp /etc/puppet/manifests.overrides/
+  mkdir -p /etc/puppet/hiera.overrides
+  sed  -i "s/  :datadir: \/etc\/puppet\/hiera\/data/  :datadir: \/etc\/puppet\/hiera.overrides\/data/" /tmp/rjil/hiera/hiera.yaml
+  cp /tmp/rjil/hiera/hiera.yaml /etc/puppet
+  cp -Rf /tmp/rjil/hiera/data /etc/puppet/hiera.overrides
+  mkdir -p /etc/puppet/modules.overrides/rjil
+  cp -Rf /tmp/rjil/* /etc/puppet/modules.overrides/rjil/
+  if [ -n "${module_git_cache}" ]
+  then
+    cd /etc/puppet/modules.overrides
+    wget -O cache.tar.gz "${module_git_cache}"
+    tar xzf cache.tar.gz
+    time librarian-puppet update --puppetfile=/tmp/rjil/Puppetfile --path=/etc/puppet/modules.overrides
+  else
+    time librarian-puppet install --puppetfile=/tmp/rjil/Puppetfile --path=/etc/puppet/modules.overrides
+  fi
+  cat <<INISETTING | puppet apply --config_version='echo settings'
+  ini_setting { basemodulepath: path => "/etc/puppet/puppet.conf", section => main, setting => basemodulepath, value => "/etc/puppet/modules.overrides:/etc/puppet/modules" }
+  ini_setting { default_manifest: path => "/etc/puppet/puppet.conf", section => main, setting => default_manifest, value => "/etc/puppet/manifests.overrides/site.pp" }
+  ini_setting { disable_per_environment_manifest: path => "/etc/puppet/puppet.conf", section => main, setting => disable_per_environment_manifest, value => "true" }
+INISETTING
+else
+  puppet apply --config_version='echo settings' -e "ini_setting { default_manifest: path => \"/etc/puppet/puppet.conf\", section => main, setting => default_manifest, value => \"/etc/puppet/manifests/site.pp\" }"
+fi
+echo 'consul_discovery_token='${consul_discovery_token} > /etc/facter/facts.d/consul.txt
+# default to first 16 bytes of discovery token
+echo 'consul_gossip_encrypt'=`echo ${consul_discovery_token} | cut -b 1-15 | base64` >> /etc/facter/facts.d/consul.txt
+echo 'current_version='${BUILD_NUMBER} > /etc/facter/facts.d/current_version.txt
+echo 'env='${env} > /etc/facter/facts.d/env.txt
+echo 'cloud_provider='${cloud_provider} > /etc/facter/facts.d/cloud_provider.txt
+if [ -n "${slack_url}" ]; then
+  echo 'slack_url=${slack_url}' > /etc/facter/facts.d/slack_url.txt
+fi
+
+##
+# Disable TCP Offloading in builds on Interfaces
+# Add network config for all available interfaces, this would be usable for
+# undercloud as it will have multiple interfaces. cloudinit will only handle
+# first interface
+#
+
+if [[ \$(facter is_virtual) == true ]];
+then
+  for nic in \$(ifconfig -a | awk '/eth[0-9]+/ {print \$1}'); do
+    netconfig_content="\$netconfig_content
+file { '/etc/network/interfaces.d/\${nic}':
+  ensure  => file,
+  content => 'auto \$nic
+iface \$nic inet dhcp
+',
+}"
+    ethtool -K \${nic} tx off
+    sed -i -e "/^exit 0$/i\ethtool -K \${nic} tx off" /etc/rc.local
+  done
+
+  puppet apply --config_version='echo settings' -e "\$netconfig_content"
+fi
+
+
+##
+# Workaround to add the swap partition for baremetal systems, as even though
+# cloudinit is creating the swap partition, its not added to the fstab and not
+# enabled.
+##
+if [ -e /dev/disk/by-label/swap1 ] && [ `grep -cP '^LABEL=swap1[\s\t]+' /etc/fstab` -eq 0 ]; then
+  echo 'LABEL=swap1 none swap sw 0 1' >> /etc/fstab
+  swapon -a
+fi
+
+while true
+do
+  # first install all packages to make the build as fast as possible
+  puppet apply --detailed-exitcodes \`puppet config print default_manifest\` --config_version='echo packages' --tags package
+  apt-get update
+  ret_code_package=\$?
+  # now perform base config
+  (echo 'File<| title == "/etc/consul" |> { purge => false }'; echo 'include rjil::jiocloud' ) | puppet apply --config_version='echo bootstrap' --detailed-exitcodes --debug
+  ret_code_jio=\$?
+  if [[ \$ret_code_jio = 1 || \$ret_code_jio = 4 || \$ret_code_jio = 6 || \$ret_code_package = 1 || \$ret_code_package = 4 || \$ret_code_package = 6 ]]
+  then
+    echo "Puppet failed. Will retry in 5 seconds"
+    sleep 5
+  else
+    break
+  fi
+done
+date
+EOF

--- a/build_scripts/make_userdata_vrouter.sh
+++ b/build_scripts/make_userdata_vrouter.sh
@@ -22,8 +22,8 @@ then
   export https_proxy=${env_https_proxy}
   echo https_proxy="'${env_https_proxy}'" >> /etc/environment
 fi
-if [ -n "${puppet_vpc_repo_url}"];then
-  if [ -z "grep '${puppet_vpc_repo_url}' /etc/apt/sources.list" ];then
+if [ -n "${puppet_vpc_repo_url}" ];then
+  if [ -z "\`grep '${puppet_vpc_repo_url}' /etc/apt/sources.list\`" ];then
     echo "deb [arch=amd64] ${puppet_vpc_repo_url} jiocloud main" | tee -a /etc/apt/sources.list
     wget -qO - ${puppet_vpc_repo_url}/repo.key | apt-key add -
   fi

--- a/build_scripts/make_userdata_vrouter.sh
+++ b/build_scripts/make_userdata_vrouter.sh
@@ -20,6 +20,7 @@ if [ -n "${env_http_proxy}" ]
 then
   export http_proxy=${env_http_proxy}
   echo http_proxy="'${env_http_proxy}'" >> /etc/environment
+  echo "Acquire::http::Proxy \"${env_http_proxy}\";" > /etc/apt/apt.conf.d/03proxy
 fi
 if [ -n "${env_https_proxy}" ]
 then
@@ -38,8 +39,7 @@ else
 fi
 wget -O jiocloud.deb -t 5 -T 30 \${jiocloud_repo_deb_url}
 dpkg -i puppet.deb jiocloud.deb
-if [ -n "${puppet_vpc_repo_url}"]
-then
+if [ -n "${puppet_vpc_repo_url}"];then
   echo "deb [arch=amd64] ${puppet_vpc_repo_url} jiocloud main" | tee -a /etc/apt/sources.list
   wget -qO - ${puppet_vpc_repo_url}/repo.key | apt-key add -
 fi

--- a/build_scripts/make_userdata_vrouter.sh
+++ b/build_scripts/make_userdata_vrouter.sh
@@ -13,6 +13,7 @@ then
   export http_proxy=${env_http_proxy}
   echo http_proxy="'${env_http_proxy}'" >> /etc/environment
   internal_subnet_exclusion=",${env_subnet}"
+  echo 'Acquire::Http::Proxy "${env_http_proxy}";' >> /etc/apt/apt.conf.d/90Proxy
   export no_proxy="127.0.0.1,169.254.169.254,localhost,consul,jiocloudservices.com\${internal_subnet_exclusion}"
   echo no_proxy="'127.0.0.1,169.254.169.254,localhost,consul,jiocloudservices.com\${internal_subnet_exclusion}'" >> /etc/environment
 fi
@@ -27,6 +28,8 @@ if [ -n "${puppet_vpc_repo_url}"];then
     wget -qO - ${puppet_vpc_repo_url}/repo.key | apt-key add -
   fi
 fi
+wget -O puppet.deb -t 5 -T 30 http://apt.puppetlabs.com/puppetlabs-release-\${release}.deb
+dpkg -i puppet.deb
 apt-get update 
 apt-get install -y puppet software-properties-common puppet-vpc
 mkdir /etc/facter

--- a/hiera/data/env/staging.yaml
+++ b/hiera/data/env/staging.yaml
@@ -314,5 +314,5 @@ contrail::vrouter::manage_repo: false
 contrail::vrouter::debug: true
 contrail::vrouter::interface_is_dhcp: false
 rjil::contrail::vrouter_standalone::discovery_address: 'vpc.staging.jiocloudservices.com'
-rjil::contrail::vrouter_standalone::vrouter_physical_interface: "%{hiera('private_interface')}"
+rjil::contrail::vrouter_standalone::vrouter_physical_interface: 'em3'
 

--- a/hiera/data/env/staging.yaml
+++ b/hiera/data/env/staging.yaml
@@ -313,3 +313,5 @@ contrail::vrouter::keystone_admin_password: "%{hiera('vpc_admin_password')}"
 contrail::vrouter::manage_repo: false
 contrail::vrouter::debug: true
 rjil::contrail::vrouter_standalone::discovery_address: 'vpc.staging.jiocloudservices.com'
+rjil::contrail::vrouter_standalone::vrouter_physical_interface: "%{hiera('private_interface')}"
+

--- a/hiera/data/env/staging.yaml
+++ b/hiera/data/env/staging.yaml
@@ -312,6 +312,7 @@ contrail::vrouter::metadata_proxy_secret: "%{hiera('nova_metadata_proxy_secret')
 contrail::vrouter::keystone_admin_password: "%{hiera('vpc_admin_password')}"
 contrail::vrouter::manage_repo: false
 contrail::vrouter::debug: true
+contrail::vrouter::interface_is_dhcp: false
 rjil::contrail::vrouter_standalone::discovery_address: 'vpc.staging.jiocloudservices.com'
 rjil::contrail::vrouter_standalone::vrouter_physical_interface: "%{hiera('private_interface')}"
 

--- a/hiera/data/env/staging.yaml
+++ b/hiera/data/env/staging.yaml
@@ -290,16 +290,12 @@ contrail::keystone_protocol: "%{hiera('keystone_protocol')}"
 contrail::nova_metadata_address: "%{hiera('nova_metadata_address')}"
 contrail::rabbit_user: "%{hiera('rabbit_admin_user')}"
 contrail::rabbit_password: "%{hiera('rabbit_admin_pass')}"
-contrail::vrouter::metadata_proxy_secret: "%{hiera('nova_metadata_proxy_secret')}"
-contrail::vrouter::keystone_admin_password: "%{hiera('vpc_admin_password')}"
 contrail::interface: "%{hiera('private_interface')}"
 contrail::manage_repo: false
-contrail::vrouter::manage_repo: false
 contrail::neutron_ip: "%{hiera('neutron_public_address')}"
 contrail::enable_analytics: false
 contrail::enable_dns: false
 contrail::dns_port: 10000
-contrail::vrouter::debug: true
 rjil::contrail::server::enable_analytics: false
 rjil::contrail::server::enable_dns: "%{hiera('contrail::enable_dns')}"
 rjil::contrail::server::dns_port: "%{hiera('contrail::dns_port')}"
@@ -311,4 +307,9 @@ contrail::config::quota_subnet: 20
 contrail::config::quota_virtual_machine_interface: 100
 contrail::config::quota_virtual_network: 5
 
-
+# Contrail Vrouter Settings
+contrail::vrouter::metadata_proxy_secret: "%{hiera('nova_metadata_proxy_secret')}"
+contrail::vrouter::keystone_admin_password: "%{hiera('vpc_admin_password')}"
+contrail::vrouter::manage_repo: false
+contrail::vrouter::debug: true
+rjil::contrail::vrouter_standalone::discovery_address: 'vpc.staging.jiocloudservices.com'

--- a/hiera/data/env/vagrant-vbox.yaml
+++ b/hiera/data/env/vagrant-vbox.yaml
@@ -104,6 +104,7 @@ rjil::base::self_signed_cert: true
 tempest::admin_password: tempest_admin
 tempest::admin_username: tempest_admin
 
+
 rjil::neutron::contrail::fip_pools:
   public:
     network_name: public
@@ -121,6 +122,7 @@ rjil::neutron::contrail::fip_pools:
 
 contrail::vrouter::vgw_subnets: ['100.1.0.0/24']
 rjil::contrail::vrouter_standalone::discovery_address: '192.168.100.75'
+contrail::vrouter::interface_is_dhcp: false
 rjil::system::apt::env_repositories:
   contrailv2:
     location: 'http://jiocloud.rustedhalo.com/contrailv2'

--- a/hiera/data/env/vagrant-vbox.yaml
+++ b/hiera/data/env/vagrant-vbox.yaml
@@ -120,7 +120,7 @@ rjil::neutron::contrail::fip_pools:
     tenants: ['tempest']
 
 contrail::vrouter::vgw_subnets: ['100.1.0.0/24']
-contrail::vrouter::discovery_address: '192.168.100.75'
+rjil::contrail::vrouter_standalone::discovery_address: '192.168.100.75'
 rjil::system::apt::env_repositories:
   contrailv2:
     location: 'http://jiocloud.rustedhalo.com/contrailv2'

--- a/hiera/data/env/vagrant-vbox.yaml
+++ b/hiera/data/env/vagrant-vbox.yaml
@@ -120,6 +120,7 @@ rjil::neutron::contrail::fip_pools:
     tenants: ['tempest']
 
 contrail::vrouter::vgw_subnets: ['100.1.0.0/24']
+contrail::vrouter::discovery_address: '192.168.100.75'
 rjil::system::apt::env_repositories:
   contrailv2:
     location: 'http://jiocloud.rustedhalo.com/contrailv2'

--- a/hiera/data/role/cp.yaml
+++ b/hiera/data/role/cp.yaml
@@ -1,1 +1,45 @@
 nova::network::neutron::network_api_class: 'nova_contrail_vif.contrailvif.ContrailNetworkAPI'
+rjil::system::apt::env_repositories:
+  contrailv2:
+    location: 'http://jiocloud.rustedhalo.com/contrailv2'
+    release: 'trusty'
+    repos: 'main'
+    include_src: false
+rjil::system::apt::repositories:
+  rustedhalo:
+    location: 'http://jiocloud.rustedhalo.com/ubuntu/'
+    release: "%{hiera('rustedhalo_apt_repo_release')}"
+    repos: 'main'
+    include_src: false
+    key: '85596F7A'
+    key_content: |
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+      Version: GnuPG v1
+
+      mQENBFM0FdsBCADbcuhgf4ny6HQXSCrskXK3hp8HUA4UbW9xIO/fqUzKTvxRuwUR
+      yRZHXVdCCaLOD8En+h4fnAs2PY3ueVfcIDt9DsJcmqWE+cbFG191Yw8hQV/MtxXU
+      YNAS6oKOwMheC3BtxdbplJ4hbg065m38wPmcgt/rJiAQZBxrKggCHTvIQunvJnmG
+      /7OMuwhkzewEAaG5E1mmdVq+IMJAg0ltMiRANASo07wrB0At4q62ozBomua6Hk3s
+      69ie5ZGiQtyIOgB1mO4RwxS0MoMd+ffq6Kyc8GPoM9EFj4zYGIyOZBa4YqI9cs9A
+      88E5910lHNx8p2wZCsN+Z00IDN3c6nGmHrzNABEBAAG0Kkppb0Nsb3VkIFJlcG9z
+      aXRvcnkgPHN1cHBvcnRAamlvY2xvdWQuY29tPokBOAQTAQIAIgUCUzQV2wIbAwYL
+      CQgHAwIGFQgCCQoLBBYCAwECHgECF4AACgkQhgQCvoVZb3oKVwf+Pr3hBs1h5oOk
+      VFHwQ/whCcnLjdY1so9wVeZ0TsZVRTrepyKB4Bi+yy4xtYZ572JLbORqRIfdOTgE
+      06cagaoi2Mc1e5sW/l0ifOvfjlrxIECMX4ftL2igZ7Cu4GB8+WmuDdHpsTdi1Fvx
+      9cn2eHAylHS3oblwoKpdfiHLPkP0Dt5aJFKOyBQfDPhjX4LF0S0aC0Zg43jNIZdf
+      nnC71P2+i5WwvljJV2+DTtp3/ImBMKVKgAISxOtBsA5PC+yP6X4lsUUwEP4amti8
+      jnq2HAjKkpM3UTAWLbHN3x6O2Mg+OIvjYUhrbYeHqQEQurUoPUx2FjZhrXDM/Cxg
+      tnaES5wRqLkBDQRTNBXbAQgAs4OQ1KlirGpiZC4hEvfmrkBKiJUk1sxsRzqqatkv
+      Ul5ay3DWoknYO+C7RIzYTwMQ9lv/QwJA2T+FpYykiu6gg872W5aje9xqg98z9DTM
+      C2lZ79yUMNiMNdKr6Zd05Q6zz0EQVaTMwrYEb+DOW0H8ka7HJA2MJc/ot0Bf2G2A
+      uavopMiikaVX67901qvHKqQMFgFzbe0C16poK057W3iFEnYAYTzJ6sLhCukfMkwk
+      6cIApeCEDz9d1tq5aiYcgXhnhnLnXBR9nUlI5qdfU/6+Nmcgh+izjtQp+U5cKHhl
+      YaiPfbVLQVUg/jbhem0XZuXJ9LdaNoeDdG+7KP7s+N+fIwARAQABiQEfBBgBAgAJ
+      BQJTNBXbAhsMAAoJEIYEAr6FWW96QewH/20zMCYcDgt8AoRJsyhLPLw8Xa8N57YD
+      EJfNUKA/74UrUSiLNktXzOVRLa1vAp5kdd9x6HNg5C0bt8kjvYzTvVChRBGt7NRg
+      SViL4sowyCFpT23JhHRajMmiJPigG+c4gjIJF4DbnpSG8WPC3jDPV891EZCodmaz
+      klc+BnhnZrb4FcB04RdQ/WXgVshDCzVQhmdIEILGKYHMTjlK/HkV6YqH7l7+jRvJ
+      phmH35+GJQumLfXWlvDchtBjUTo5ZDCa7TWhwhXZoFg5nxadQDX4TwHhZBQH1TX5
+      Chk4NnD90SYZt36sTLITe5O/BgYlRMqVo+bVj0tmjMJP/B4PZjABX7A=
+      =iZW7
+      -----END PGP PUBLIC KEY BLOCK-----

--- a/hiera/data/role/cp.yaml
+++ b/hiera/data/role/cp.yaml
@@ -1,4 +1,5 @@
 nova::network::neutron::network_api_class: 'nova_contrail_vif.contrailvif.ContrailNetworkAPI'
+rjil::system::apt::proxy: false
 contrail::vrouter::lbaas: false
 rjil::system::apt::env_repositories:
   contrailv2:

--- a/hiera/data/role/cp.yaml
+++ b/hiera/data/role/cp.yaml
@@ -1,4 +1,5 @@
 nova::network::neutron::network_api_class: 'nova_contrail_vif.contrailvif.ContrailNetworkAPI'
+contrail::vrouter::lbaas: false
 rjil::system::apt::env_repositories:
   contrailv2:
     location: 'http://jiocloud.rustedhalo.com/contrailv2'

--- a/manifests/contrail/vrouter_standalone.pp
+++ b/manifests/contrail/vrouter_standalone.pp
@@ -11,7 +11,7 @@ class rjil::contrail::vrouter_standalone (
 
   include rjil::jiocloud
   include rjil::default_manifest
-
+  include rjil::test::base
 
   class {'::contrail::vrouter':
     discovery_address => $discovery_address,

--- a/manifests/contrail/vrouter_standalone.pp
+++ b/manifests/contrail/vrouter_standalone.pp
@@ -1,0 +1,23 @@
+###
+# Class: rjil::contrail::vrouter_standalone
+#
+###
+
+class rjil::contrail::vrouter_standalone (
+  $discovery_address = join(service_discover_dns('lb.neutron.service.consul','name')),
+  $api_address       = undef,
+  $vrouter_physical_interface = 'eth1'
+) {
+
+  include rjil::jiocloud
+  include rjil::default_manifest
+
+
+  class {'::contrail::vrouter':
+    discovery_address => $discovery_address,
+    api_address       => $api_address,
+    vrouter_physical_interface => $vrouter_physical_interface,
+  }
+
+
+}

--- a/manifests/contrail/vrouter_standalone.pp
+++ b/manifests/contrail/vrouter_standalone.pp
@@ -11,6 +11,7 @@ class rjil::contrail::vrouter_standalone (
 
   #include rjil::jiocloud
   include rjil::default_manifest
+  include rjil::system::apt
   #include rjil::test::base
 
   class {'::contrail::vrouter':

--- a/manifests/contrail/vrouter_standalone.pp
+++ b/manifests/contrail/vrouter_standalone.pp
@@ -9,9 +9,9 @@ class rjil::contrail::vrouter_standalone (
   $vrouter_physical_interface = 'eth1'
 ) {
 
-  include rjil::jiocloud
+  #include rjil::jiocloud
   include rjil::default_manifest
-  include rjil::test::base
+  #include rjil::test::base
 
   class {'::contrail::vrouter':
     discovery_address => $discovery_address,

--- a/site.pp
+++ b/site.pp
@@ -34,7 +34,7 @@ node /^vpc-ctrl\d+/ {
 
 
 node /^cp\d+/ {
-  include rjil::contrail::vrouter
+  include rjil::contrail::vrouter_standalone
 }
 
 #Adding CP nodes for full integration testing


### PR DESCRIPTION
This Patch will help in deploying standalone vrouter in Staging environment. The script generated with all parameters from make_userdata_vrouter.txt will be used as a deploy mechanisim for deploying vrouter on a compute nodes.

This will not update cron entries or install consul. This discovery service endpoint need to be mentioned in the staging hieral