### PR TITLE
Fixed issues during vagrant provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure("2") do |config|
   # which effect the hiera hierarchy and the
   # cloud file that is used
   environment = ENV['env'] || 'vagrant-vbox'
-  layout = ENV['layout'] || 'full'
+  layout = ENV['layout'] || 'vagrant-full'
   map = ENV['map'] || environment
 
   config.vm.provider :virtualbox do |vb, override|

--- a/hiera/data/env/vagrant-vbox.yaml
+++ b/hiera/data/env/vagrant-vbox.yaml
@@ -127,6 +127,15 @@ rjil::system::apt::env_repositories:
     release: 'trusty'
     repos: 'main'
     include_src: false
+  glance-image:
+    location: 'http://10.140.221.229/apt/vpramo/glance'
+    release: 'jiocloud'
+    repos: 'main'
+    include_src: false
+    pin: 800
+    key:
+      id: '53046A7C'
+      source: 'http://10.140.221.229/apt/vpramo/glance/repo.key'
 
 ntp::servers:
   - 10.140.221.235

--- a/manifests/cinder.pp
+++ b/manifests/cinder.pp
@@ -92,7 +92,6 @@ class rjil::cinder (
 
   include rjil::apache
 
-  Service['cinder-api'] -> Service['httpd']
 
   ##
   # Ceph backend causing lot of open sockets to ceph osds, so increasing

--- a/manifests/glance.pp
+++ b/manifests/glance.pp
@@ -41,8 +41,6 @@ class rjil::glance (
 
   include rjil::apache
 
-  Service['glance-api'] -> Service['httpd']
-  Service['glance-registry'] -> Service['httpd']
 
   ## Configure apache reverse proxy
   apache::vhost { 'glance-api':

--- a/manifests/nova/controller.pp
+++ b/manifests/nova/controller.pp
@@ -49,7 +49,6 @@ class rjil::nova::controller (
   }
 
   include rjil::apache
-  Service['nova-api'] -> Service['httpd']
 
   ## Configure apache reverse proxy
   apache::vhost { 'nova-osapi':


### PR DESCRIPTION
This patch fixes couple of issues which were causing issues in setting up manual provisioning. 

1. manual restart of apache service in keystone1 server
2. Glance ssl & EOF patch not available in upstream debian package

