### PR TITLE
Fix ec2api ports and add nova and neutron endpoints

### DIFF
--- a/hiera/data/env/staging.yaml
+++ b/hiera/data/env/staging.yaml
@@ -384,6 +384,12 @@ ec2api::ec2api_config:
     value: '/etc/ec2api/api-paste.ini'
   DEFAULT/ec2api_use_ssl:
     value: true
+  DEFAULT/ec2api_listen_port:
+    value: '443'
+  DEFAULT/neutron_endpoint_url:
+    value: 'https://vpc.ind-west-1.staging.jiocloudservices.com:9696'
+  DEFAULT/nova_endpoint_url:
+    value: 'https://compute.ind-west-1.staging.jiocloudservices.com:8774/v2'
   DEFAULT/ssl_cert_file:
     value: '/etc/ssl/certs/vpc.ind-west-1.staging.jiocloudservices.com.crt'
   DEFAULT/ssl_key_file:

--- a/hiera/data/env/staging.yaml
+++ b/hiera/data/env/staging.yaml
@@ -48,7 +48,7 @@ rjil::system::apt::env_repositories:
       id: '5DC149F6'
       source: 'http://10.140.221.229/apt/vpcjiocloud/vpcjiocloud/repo.key'
   contrail-main:
-    location: 'http://10.140.221.229/snapshots/cf0b5774-c3cc-4532-b774-85e20fa6b6ee/10.140.221.229/apt/vpcjiocloud/contrail/'
+    location: 'http://10.140.221.229/snapshots/85d43f48-b063-467d-8532-daa2998646fa/10.140.221.229/apt/vpcjiocloud/contrail/'
     release: 'jiocloud'
     repos: 'main'
     include_src: false

--- a/hiera/data/env/staging.yaml
+++ b/hiera/data/env/staging.yaml
@@ -227,10 +227,10 @@ rjil::haproxy::default_timeout_server: 50000
 
 # Keystone Properties
 rjil::jiocloud::dns::entries:
-  iam.ind-west-1.staging.deprecated.jiocloudservices.com:
-    cname: iam.ind-west-1.staging.deprecated.jiocloudservices.com
-keystone_public_address: iam.ind-west-1.staging.deprecated.jiocloudservices.com
-keystone_private_address: iam.ind-west-1.staging.deprecated.jiocloudservices.com
+  iam.ind-west-1.staging.jiocloudservices.com:
+    cname: iam.ind-west-1.staging.jiocloudservices.com
+keystone_public_address: iam.ind-west-1.staging.jiocloudservices.com
+keystone_private_address: iam.ind-west-1.staging.jiocloudservices.com
 keystone_port: 5000
 keystone_admin_port: 35357
 keystone_protocol: https

--- a/hiera/data/env/vagrant-vbox.yaml
+++ b/hiera/data/env/vagrant-vbox.yaml
@@ -137,7 +137,7 @@ rjil::system::apt::env_repositories:
       id: '5DC149F6'
       source: 'http://10.140.221.229/apt/vpcjiocloud/vpcjiocloud/repo.key'
   contrail-main:
-    location: 'http://10.140.221.229/snapshots/cf0b5774-c3cc-4532-b774-85e20fa6b6ee/10.140.221.229/apt/vpcjiocloud/contrail/'
+    location: 'http://10.140.221.229/snapshots/85d43f48-b063-467d-8532-daa2998646fa/10.140.221.229/apt/vpcjiocloud/contrail/'
     release: 'jiocloud'
     repos: 'main'
     include_src: false

--- a/manifests/haproxy/contrail.pp
+++ b/manifests/haproxy/contrail.pp
@@ -27,7 +27,7 @@ class rjil::haproxy::contrail(
   $ec2api_server_vip       = undef,
   $ec2api_backend_ips      = sort(values(service_discover_consul('ec2api'))),
   $ec2api_listen_ports     = 443,
-  $ec2api_balancer_port    = 8788,
+  $ec2api_balancer_port    = 443,
   $min_members             = '3',
 ) {
 


### PR DESCRIPTION
Patch to fix ec2api port from 8788 to 443 and also change in endpoint change from deprecated IAM to new IAM